### PR TITLE
Turns the USB device into an ethernet port

### DIFF
--- a/board/cuprous/gw/rootfs_overlay/etc/modules-load.d/g_gadget.conf
+++ b/board/cuprous/gw/rootfs_overlay/etc/modules-load.d/g_gadget.conf
@@ -1,0 +1,4 @@
+g_ether
+# Comment the above, and uncomment the below if a tty console is required on the USB device instead of ethernet
+# g_serial
+

--- a/board/cuprous/gw/rootfs_overlay/etc/modules-load.d/g_serial.conf
+++ b/board/cuprous/gw/rootfs_overlay/etc/modules-load.d/g_serial.conf
@@ -1,1 +1,0 @@
-g_serial

--- a/board/cuprous/gw/rootfs_overlay/etc/systemd/network/20-usb0.network
+++ b/board/cuprous/gw/rootfs_overlay/etc/systemd/network/20-usb0.network
@@ -1,0 +1,6 @@
+[Match]
+Name=usb0
+
+[Network]
+Bridge=config-br0
+


### PR DESCRIPTION
We now use the USB device to carry ethernet and bridge with the configuration interface. This provides an alternative to using WiFi to connect to the AP from another machine. Connecting to 192.168.3.1 will then behave as per connecting via an AP.

This functionality replaces the use of the USB device for console access. That can be re-enabled if required by following the commented instructions in the `g_gadget.conf` file. You can't have serial and ethernet on the same device though.

Evidence of having connected my Mac to the EK:
![image](https://github.com/cuprous-au/buildroot-external-cuprous/assets/694893/ee69469c-9411-4dcc-a9a1-9a9d4145ff23)

Further evidence of the configuration on the gateway:

```
# ip link show master config-br0
5: usb0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master config-br0 state UP mode DEFAULT group default qlen 1000
    link/ether da:52:8c:da:3a:67 brd ff:ff:ff:ff:ff:ff
7: config0: <BROADCAST,NOARP,UP,LOWER_UP> mtu 1500 qdisc noqueue master config-br0 state UNKNOWN mode DEFAULT group default qlen 1000
    link/ether 3e:e1:32:7b:ba:99 brd ff:ff:ff:ff:ff:ff
9: ap0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast master config-br0 state UP mode DEFAULT group default qlen 1000
    link/ether fa:f0:05:5a:55:00 brd ff:ff:ff:ff:ff:ff
```