### PR TITLE
Reset channel

### DIFF
--- a/board/cuprous/gw/rootfs_overlay/etc/systemd/system/hostapd-ap0-configure.sh
+++ b/board/cuprous/gw/rootfs_overlay/etc/systemd/system/hostapd-ap0-configure.sh
@@ -9,6 +9,16 @@ MAC_ID=$(cat /sys/class/net/wlan0/address | tr -d ':' | tail -c5)
 sed -i -e "s/^ssid=.*/ssid=Cuprous-${MAC_ID}/" /etc/hostapd/hostapd-ap0.conf
 sed -i -e "s/^wpa_passphrase=.*/wpa_passphrase=${MAC_ID}${MAC_ID}/" /etc/hostapd/hostapd-ap0.conf
 
+# We configure ap0 to have the same channel as wlan0 if it is active, or back
+# to a sensible default if not.
+CHANNEL=$(/sbin/iwlist wlan0 channel | grep "Current Frequency" | grep -Eo '[0-9]+')
+if [ $? -eq 0 ]; then
+    CHANNEL=$(echo "$CHANNEL" | tail -1)
+else
+    CHANNEL=1
+fi
+sed -i -e "s/^channel=.*/channel=${CHANNEL}/" /etc/hostapd/hostapd-ap0.conf
+
 # We also configure the ap0 interface here as hostapd will remove it on a restart. Thus,
 # it cannot be a udev rule. Why hostapd decides that it an external responsibility to
 # create it, but not to delete it is mysterious.

--- a/board/cuprous/gw/rootfs_overlay/etc/systemd/system/hostapd-chan-switch-ap0.sh
+++ b/board/cuprous/gw/rootfs_overlay/etc/systemd/system/hostapd-chan-switch-ap0.sh
@@ -2,16 +2,11 @@
 
 case "$2" in
   CONNECTED)
-    echo "WPA supplicant: connection established - assigning the same channel for the AP";
-    # Use the current frequency in our config if the wlan0 is connected
-    CURRENT_CHANNEL=$(/sbin/iwlist wlan0 channel | grep "Current Frequency" | grep -Eo '[0-9]+')
-    if [ $? -eq 0 ]; then
-      CURRENT_CHANNEL=$(echo "$CURRENT_CHANNEL" | tail -1)
-      sed -i -e "s/^channel=.*/channel=${CURRENT_CHANNEL}/" /etc/hostapd/hostapd-ap0.conf
-      /bin/systemctl try-restart hostapd@ap0.service
-    fi
+    echo "WPA supplicant: connection established - restarting hostapd";
+    /bin/systemctl try-restart hostapd@ap0.service
     ;;
   DISCONNECTED)
-    echo "WPA supplicant: connection lost";
+    echo "WPA supplicant: connection lost - restarting hostapd";
+    /bin/systemctl try-restart hostapd@ap0.service
     ;;
 esac


### PR DESCRIPTION
We now set/reset the channel for hostapd as part of its configuration during service startup. We also restart hostapd when wpa_supplicant goes down. This logic should guarantee that the AP channel is always set to something suitable.﻿

Tested on the EK. Seems ok.