### PR TITLE
allow installer wired access 

### DIFF
--- a/board/cuprous/raspberrypi5_cuprous_gw/rootfs_overlay/etc/systemd/network/20-enu1.network
+++ b/board/cuprous/raspberrypi5_cuprous_gw/rootfs_overlay/etc/systemd/network/20-enu1.network
@@ -1,0 +1,6 @@
+[Match]
+Name=enu1
+
+[Network]
+Bridge=config-br0
+


### PR DESCRIPTION
 Plugging ethernet dongle in a host port (ie either usb 3 A) creates interface enu1 which is then added to the config-br0 bridge.