### PR TITLE
Enable the USB device port

### DIFF
--- a/board/cuprous/raspberrypi5_cuprous_gw/config_5.txt
+++ b/board/cuprous/raspberrypi5_cuprous_gw/config_5.txt
@@ -1,6 +1,9 @@
 # Custom overlay
 dtoverlay=raspberrypi5_cuprous_gw-overlay
 
+# Enable USB device port
+dtoverlay=dwc2
+
 # Enable UARTs for RS485
 dtoverlay=uart2-pi5,ctsrts=off
 dtoverlay=uart3-pi5,ctsrts=off

--- a/board/cuprous/raspberrypi5_cuprous_gw/rootfs_overlay/etc/nftables.conf
+++ b/board/cuprous/raspberrypi5_cuprous_gw/rootfs_overlay/etc/nftables.conf
@@ -20,6 +20,9 @@ table ip gateway {
         # accepting ping (icmp-echo-request) for diagnostic purposes.
         icmp type echo-request limit rate 5/second accept
 
+        # Allow DHCP clients
+        udp dport 67 accept
+
         # allow http access to the configurator
         tcp dport http accept
     }


### PR DESCRIPTION
This lets g_ether do its thing and /dev/usb0 will now appear when a host is plugged into the USB C device port. This interface will then be added to the config-br0.  

However, dhcpd does not seem to be working on bridge. - Now fixed.